### PR TITLE
Moved awaiting to a dev dependency and expanded allowed engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "artillery": "^1.6.0-2",
+    "awaiting": "^2.2.0",
     "chai": "^3.5.0",
     "documentation": "^4.0.0-rc.1",
     "mocha": "^3.4.1",
@@ -26,8 +27,5 @@
     "nyc": "^10.3.2",
     "requisition": "^1.7.0",
     "standard": "^8.6.0"
-  },
-  "dependencies": {
-    "awaiting": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stoppable",
   "version": "1.0.3",
   "engines": {
-    "node": ">=7.6.0"
+    "node": ">=6"
   },
   "keywords": [],
   "scripts": {


### PR DESCRIPTION
I noticed `awaiting` was only used in the tests so I moved it to a dev dependency. I also noticed that this package works fine for me on node 6 so I expanded the viable engines.

Let me know if there's anything more you'd like me to do here, and thanks for the great module!