### PR TITLE
Add gracefully argument to the callback

### DIFF
--- a/lib/stoppable.js
+++ b/lib/stoppable.js
@@ -6,6 +6,7 @@ module.exports = (server, grace) => {
   grace = typeof grace === 'undefined' ? Infinity : grace
   const reqsPerSocket = new Map()
   let stopped = false
+  let gracefully = true
 
   if (server instanceof https.Server) {
     server.on('secureConnection', onConnection)
@@ -41,7 +42,11 @@ module.exports = (server, grace) => {
       if (grace < Infinity) {
         setTimeout(destroyAll, grace).unref()
       }
-      server.close(callback)
+      server.close(e => {
+        if (callback) {
+          callback(e, gracefully)
+        }
+      })
       reqsPerSocket.forEach(endIfIdle)
     })
   }
@@ -51,6 +56,7 @@ module.exports = (server, grace) => {
   }
 
   function destroyAll () {
+    gracefully = false
     reqsPerSocket.forEach((reqs, socket) => socket.end())
     setImmediate(() => {
       reqsPerSocket.forEach((reqs, socket) => socket.destroy())

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,8 @@ server.stop(callback)
 
 Closes the server.
 
-- callback: passed along to the existing `server.close` function to auto-register a 'close' event
+- callback: passed along to the existing `server.close` function to auto-register a 'close' event.
+The first agrument is an error, and the second argument is a boolean that indicates whether it stopped gracefully.
 
 ## Design decisions
 


### PR DESCRIPTION
I made it to call a callback passed to server.stop with an extra argument. Now it calls it with two arguments. The first argument is an error, and the second argument is a boolean that indicates if it stopped gracefully.

This argument is useful to log whether it stopped gracefully or not.