### PR TITLE
support Node.js >= v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 coverage
 .nyc_output
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ language: node_js
 node_js:
   - '9'
   - '8'
-  - '6'
-  - '4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+sudo: false
 language: node_js
 node_js:
-  - "7.6.0"
-  - "node"
-script: yarn test
+  - '9'
+  - '8'
+  - '6'
+  - '4'

--- a/lib/stoppable.js
+++ b/lib/stoppable.js
@@ -1,4 +1,7 @@
-module.exports = (server, grace = Infinity) => {
+'use strict'
+
+module.exports = (server, grace) => {
+  grace = typeof grace === 'undefined' ? Infinity : grace
   const reqsPerSocket = new Map()
   let stopped = false
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stoppable",
   "version": "1.0.3",
   "engines": {
-    "node": ">=6"
+    "node": ">=4"
   },
   "keywords": [],
   "repository": "hunterloftis/stoppable",


### PR DESCRIPTION
[Node-RED](https://github.com/node-red/node-red) wishes to use `stoppable` in its test suite, but it needs to support Node.js v4.

Since the changes to support this version of Node.js are few, I'm hoping you'll accept this PR.