### PR TITLE
Fix handling of in-flight requests on an HTTPS server

### DIFF
--- a/lib/stoppable.js
+++ b/lib/stoppable.js
@@ -1,12 +1,18 @@
 'use strict'
 
+const https = require('https')
+
 module.exports = (server, grace) => {
   grace = typeof grace === 'undefined' ? Infinity : grace
   const reqsPerSocket = new Map()
   let stopped = false
 
-  server.on('connection', onConnection)
-  server.on('secureConnection', onConnection)
+  if (server instanceof https.Server) {
+    server.on('secureConnection', onConnection)
+  } else {
+    server.on('connection', onConnection)
+  }
+
   server.on('request', onRequest)
   server.stop = stop
   server._pendingSockets = reqsPerSocket


### PR DESCRIPTION
While testing the `stoppable` lib on Node `8.9.3` I found out that it doesn't work correctly on an HTTPS server. My understanding of the bug is:
- it both listen on `connection` and `secureConnection` events
- in case of an HTTPS connection, both events are fired, but what we really want is the `secureConnection` which is fired once the TLS connection is successfully established (compared to when the TCP connection is established)
- when we handle events from both listeners for the "same" socket something weird happen with the map and basically **no** in-flight request is tracked with the map, causing the "graceful" shutdown to be an "hard" shutdown (all sockets immediately closed by `reqsPerSocket.forEach(endIfIdle)` because even sockets with in-flight requests are considered idle 

This PR should fix it (according to my manual tests and the unit tests I've added).
