### PR TITLE
add stopAsync(); closes #18

### DIFF
--- a/lib/stoppable.js
+++ b/lib/stoppable.js
@@ -16,6 +16,7 @@ module.exports = (server, grace) => {
 
   server.on('request', onRequest)
   server.stop = stop
+  server.stopAsync = stopAsync
   server._pendingSockets = reqsPerSocket
   return server
 
@@ -48,6 +49,17 @@ module.exports = (server, grace) => {
         }
       })
       reqsPerSocket.forEach(endIfIdle)
+    })
+  }
+
+  function stopAsync () {
+    return new Promise((resolve, reject) => {
+      server.stop((err, gracefully) => {
+        if (err) {
+          return reject(err)
+        }
+        resolve(gracefully)
+      })
     })
   }
 

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,16 @@ Closes the server.
 - callback: passed along to the existing `server.close` function to auto-register a 'close' event.
 The first agrument is an error, and the second argument is a boolean that indicates whether it stopped gracefully.
 
+**stopAsync()**
+
+```js
+await server.stopAsync()
+```
+
+Closes the server, `Promise`-style.
+
+Resolves with a boolean that indicates whether it stopped gracefully.
+
 ## Design decisions
 
 - Monkey patching generally sucks, but in this case it's the nicest API. Let's call it "decorating."


### PR DESCRIPTION
This implementation should be minimally disruptive and make it easy to use `async`/`await`/`Promise`s.

cc @novemberborn @ronkorving

From docs:

* * * 

**stopAsync()**

```js
await server.stopAsync()
```

Closes the server, `Promise`-style.

Resolves with a boolean that indicates whether it stopped gracefully.
