### PR TITLE
Avoid using timer.unref

### DIFF
--- a/lib/stoppable.js
+++ b/lib/stoppable.js
@@ -39,10 +39,15 @@ module.exports = (server, grace) => {
     // allow request handlers to update state before we act on that state
     setImmediate(() => {
       stopped = true
+      let timeout = null
       if (grace < Infinity) {
-        setTimeout(destroyAll, grace).unref()
+        timeout = setTimeout(destroyAll, grace)
       }
       server.close(e => {
+        if (timeout) {
+          clearTimeout(timeout)
+          timeout = null
+        }
         if (callback) {
           callback(e, gracefully)
         }


### PR DESCRIPTION
Some environments where you might use stoppable don't implement timer.unref,
such as the "jsdom" browser-compatibility mode of jest.

This uses clearTimeout instead of unref to fix issue #1 in a more compatible way
which still passes the test added in #3.