### PR TITLE
Allow overriding grace period in param to `stop`

### DIFF
--- a/lib/stoppable.js
+++ b/lib/stoppable.js
@@ -35,12 +35,19 @@ module.exports = (server, grace) => {
     })
   }
 
-  function stop (callback) {
+  function stop (graceOverride, callback) {
+    let gracePeriod = grace;
+
+    if (typeof callback === 'undefined') {
+      callback = graceOverride;
+    } else {
+      gracePeriod = graceOverride;
+    }
     // allow request handlers to update state before we act on that state
     setImmediate(() => {
       stopped = true
-      if (grace < Infinity) {
-        setTimeout(destroyAll, grace).unref()
+      if (gracePeriod < Infinity) {
+        setTimeout(destroyAll, gracePeriod).unref()
       }
       server.close(e => {
         if (callback) {


### PR DESCRIPTION
We have a case where we want to have an overall grace period for our entire service. We shut down some things, then we start shutting down our Express server.

This means that the grace period we give to `stoppable` depends on how much is left of our overall grace period, based on how long those other things took to stop, and so we can't calculate it up front. This patch allows the grace period to be passed directly to `stop` - which is the only place that it's used - as well.

If `stop` receives two arguments, then the first is the grace period (which takes precedence over the one set on `stoppable`) and the second is the callback. If it takes one argument, then that argument is the callback, to maintain compatibility.